### PR TITLE
Remove unnecessary parts from `lint-staged` scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
 	},
 	"lint-staged": {
 		"*.css": [
-			"stylelint --formatter verbose --max-warnings 0",
+			"stylelint --max-warnings 0",
 			"prettier --write"
 		],
 		"*.js": [
 			"eslint --max-warnings 0",
 			"prettier --write"
 		],
-		"**/!(*.css|*.js)": [
+		"!(*.css|*.js)": [
 			"prettier --write --ignore-unknown"
 		]
 	},


### PR DESCRIPTION
To match https://github.com/germanfrelo/template/commit/51fd5098b56401fd6c3b5b2d6f86578d24fdbe16.