### PR TITLE
Run package commands directly in pre-commit file without npx

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+lint-staged


### PR DESCRIPTION
Since [husky v9.1.1](https://github.com/typicode/husky/releases/tag/v9.1.1).