### PR TITLE
chore: prevent commits on main & prompt to install deps when necessary

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+. ./.husky/scripts/check-package-lock.sh

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+. ./.husky/scripts/check-package-lock.sh

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,15 @@
+#!/bin/sh
+
+# Prevents commits on main or in detached HEAD state.
+branch="$(git branch --show-current)"
+if [ -z "$branch" ]; then # Check for empty branch name (detached HEAD)
+	echo "🚫 You are in a detached HEAD state. Checkout a branch before committing."
+	exit 1
+elif [ "$branch" = "main" ]; then # Check for direct commit to main
+	echo "🚫 Direct commits to main branch are not allowed. Create a separate branch."
+	exit 1
+fi
+
+# Runs lint-staged on staged files before commit.
+echo "Running lint-staged on staged files..."
 lint-staged

--- a/.husky/scripts/check-package-lock.sh
+++ b/.husky/scripts/check-package-lock.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Checks for package-lock.json changes, and if found, prompts to run 'npm ci'.
+
+# Check if inside a git repository
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	exit 0 # Skip silently
+fi
+
+# Check if there are any commits yet
+if ! git rev-parse --quiet HEAD >/dev/null 2>&1; then
+	exit 0 # Skip silently
+fi
+
+# Check if package-lock.json exists
+if [ ! -f "package-lock.json" ]; then
+	exit 0 # Skip silently
+fi
+
+# Check for changes in package-lock.json
+if ! git diff --quiet HEAD@{1} HEAD -- package-lock.json >/dev/null 2>&1; then
+	if ! git rev-parse --verify HEAD@{1} >/dev/null 2>&1; then
+		echo "📦ℹ️ Initial checkout. Run 'npm ci' to install dependencies."
+	else
+		echo "📦❗ package-lock.json has changed. Run 'npm ci' to update dependencies."
+	fi
+fi


### PR DESCRIPTION
- Prevents commits on main or in detached HEAD state when running git commit.
- Checks for package-lock.json changes when running git checkout/merge/pull/switch, and if found, prompts to run 'npm ci'.

Sync from https://github.com/germanfrelo/template/commit/42904b68bd051e9a38f45c7c61711f9af5319265