### PR TITLE
refactor: Create reusable social links partial

### DIFF
--- a/src/_includes/partials/site-footer.html
+++ b/src/_includes/partials/site-footer.html
@@ -1,51 +1,6 @@
 <footer class="site-footer">
 	<div class="center flow">
-		<ul role="list" class="cluster gutter-m flex-justify-center">
-			<li>
-				<a class="link-only-icon" href="https://www.linkedin.com/in/germanfrelo" rel="external me">
-					<svg class="icon" width="24" height="24" aria-hidden="true">
-						<use href="#logo-linkedin"></use>
-					</svg>
-					<span class="visually-hidden">LinkedIn</span>
-				</a>
-			</li>
-
-			<li>
-				<a class="link-only-icon" href="https://github.com/germanfrelo" rel="external me">
-					<svg class="icon" width="24" height="24" aria-hidden="true">
-						<use href="#logo-github"></use>
-					</svg>
-					<span class="visually-hidden">Github</span>
-				</a>
-			</li>
-
-			<li>
-				<a class="link-only-icon" href="https://codepen.io/germanfrelo" rel="external me">
-					<svg class="icon" width="24" height="24" aria-hidden="true">
-						<use href="#logo-codepen"></use>
-					</svg>
-					<span class="visually-hidden">CodePen</span>
-				</a>
-			</li>
-
-			<li>
-				<a class="link-only-icon" href="https://bsky.app/profile/germanfrelo.dev" rel="external me">
-					<svg class="icon" width="24" height="24" aria-hidden="true">
-						<use href="#logo-bluesky"></use>
-					</svg>
-					<span class="visually-hidden">Bluesky</span>
-				</a>
-			</li>
-
-			<li>
-				<a class="link-only-icon" href="https://front-end.social/@germanfrelo" rel="external me">
-					<svg class="icon" width="24" height="24" aria-hidden="true">
-						<use href="#logo-mastodon"></use>
-					</svg>
-					<span class="visually-hidden">Mastodon</span>
-				</a>
-			</li>
-		</ul>
+		{% include "partials/social-links.html" %}
 
 		<p>
 			This site was built using open web standards and

--- a/src/_includes/partials/social-links.html
+++ b/src/_includes/partials/social-links.html
@@ -1,0 +1,46 @@
+<ul role="list" class="cluster gutter-m flex-justify-center">
+	<li>
+		<a class="link-only-icon" href="https://www.linkedin.com/in/germanfrelo" rel="external me">
+			<svg class="icon" width="24" height="24" aria-hidden="true">
+				<use href="#logo-linkedin"></use>
+			</svg>
+			<span class="visually-hidden">LinkedIn</span>
+		</a>
+	</li>
+
+	<li>
+		<a class="link-only-icon" href="https://github.com/germanfrelo" rel="external me">
+			<svg class="icon" width="24" height="24" aria-hidden="true">
+				<use href="#logo-github"></use>
+			</svg>
+			<span class="visually-hidden">Github</span>
+		</a>
+	</li>
+
+	<li>
+		<a class="link-only-icon" href="https://codepen.io/germanfrelo" rel="external me">
+			<svg class="icon" width="24" height="24" aria-hidden="true">
+				<use href="#logo-codepen"></use>
+			</svg>
+			<span class="visually-hidden">CodePen</span>
+		</a>
+	</li>
+
+	<li>
+		<a class="link-only-icon" href="https://bsky.app/profile/germanfrelo.dev" rel="external me">
+			<svg class="icon" width="24" height="24" aria-hidden="true">
+				<use href="#logo-bluesky"></use>
+			</svg>
+			<span class="visually-hidden">Bluesky</span>
+		</a>
+	</li>
+
+	<li>
+		<a class="link-only-icon" href="https://front-end.social/@germanfrelo" rel="external me">
+			<svg class="icon" width="24" height="24" aria-hidden="true">
+				<use href="#logo-mastodon"></use>
+			</svg>
+			<span class="visually-hidden">Mastodon</span>
+		</a>
+	</li>
+</ul>


### PR DESCRIPTION
This commit moves the social links section into a dedicated, reusable file. This eliminates code duplication, improves maintainability, and establishes a single source of truth for social media links across the website.